### PR TITLE
Fix env file example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ cd localodrive
 composer install
 ```
 
-3. Copiez le fichier `.env.example` en `.env` et configurez vos variables d'environnement :
+3. Copiez le fichier `.env.exemple` en `.env` et configurez vos variables d'environnement :
 ```bash
-cp .env.example .env
+cp .env.exemple .env
 ```
 
 4. Configurez les variables dans le fichier `.env` :


### PR DESCRIPTION
## Summary
- correct `.env` example filename in installation instructions

## Testing
- `grep -n "\.env.exemple" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_68447d97169c8332a043e8960ba372e9