### PR TITLE
Fix typos in env example

### DIFF
--- a/.env.exemple
+++ b/.env.exemple
@@ -2,11 +2,11 @@
 API_KEY_SIRENE=API_key_sirene
 
 
-#configuration RECAPTCHA (RECAPTCHA pour evité spam formulaire de contacte)
+#configuration RECAPTCHA (RECAPTCHA pour evité spam formulaire de contact)
 RECAPTCHA_SITE_KEY=votre_cle_site_recaptcha
 RECAPTCHA_SECRET_KEY=votre_cle_secrete_recaptcha
 
-#configuration dedier au serveur mail / formulaire de contacte
+#configuration dedier au serveur mail / formulaire de contact
 MAIL_HOST=mail.domain.tld
 MAIL_PORT=587
 MAIL_ENCRYPTION=tls
@@ -14,7 +14,7 @@ MAIL_USERNAME=usrname
 MAIL_PASSWORD=password
 MAIL_FROM_ADDRESS=votre_mail@domaine.tld
 MAIL_FROM_NAME="name_expeditor"
-MAIL_TO_ADDRESSES="user1@exemple.com,user2@exemple.com" # liste des mail qui recevrons le mail du formulaire de contacte
+MAIL_TO_ADDRESSES="user1@exemple.com,user2@exemple.com" # liste des mail qui recevront le mail du formulaire de contacte
 
 # Configuration de la base de données
 DB_HOST=localhost


### PR DESCRIPTION
## Summary
- fix typos in `.env.exemple` comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68447d4fa85883328f0c28ce8a33339f