### PR TITLE
Add PHPUnit cart test

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Pour le développement local :
 1. Assurez-vous que `APP_ENV=development` dans votre `.env`
 2. Les erreurs seront affichées en mode développement
 3. Utilisez XAMPP ou un serveur web local
+4. Lancez les tests unitaires avec `composer test`
 
 ## Production
 

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,11 @@
     "require": {
         "vlucas/phpdotenv": "^5.6",
         "phpmailer/phpmailer": "^6.10"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.2"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit tests"
     }
 }

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -1,0 +1,52 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/functions.php';
+
+class CartTest extends TestCase
+{
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec(
+            "CREATE TABLE paniers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL
+            );"
+        );
+
+        $this->pdo->exec(
+            "CREATE TABLE panier_details (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                panier_id INTEGER NOT NULL,
+                produit_id INTEGER NOT NULL,
+                quantite INTEGER NOT NULL
+            );"
+        );
+    }
+
+    public function testAjouterAuPanierCreeUnEnregistrementAvecQuantite()
+    {
+        $userId = 1;
+        $produitId = 42;
+        $quantite = 3;
+
+        $result = ajouterAuPanier($this->pdo, $userId, $produitId, $quantite);
+        $this->assertTrue($result);
+
+        $stmt = $this->pdo->prepare(
+            "SELECT pd.quantite FROM panier_details pd
+             JOIN paniers p ON pd.panier_id = p.id
+             WHERE p.user_id = ? AND pd.produit_id = ?"
+        );
+        $stmt->execute([$userId, $produitId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertIsArray($row);
+        $this->assertEquals($quantite, $row['quantite']);
+    }
+}


### PR DESCRIPTION
## Summary
- add phpunit as dev dependency and test script
- document running the test suite
- create CartTest using in-memory SQLite

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68447dc3203883329aab0a9db7f58381