### PR TITLE
Fix English product column names

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -56,10 +56,10 @@ function ajouterAuPanier($pdo, $user_id, $produit_id, $quantite = 1) {
  */
 function getPanier($pdo, $user_id) {
     try {
-        $sql = "SELECT p.*, pr.nom as produit_nom, pr.prix, pr.image_url, pr.stock, pr.unite, prd.nom as producteur_nom 
-                FROM panier_details p 
-                JOIN produits pr ON p.produit_id = pr.id 
-                JOIN producteurs prd ON pr.producteur_id = prd.id 
+        $sql = "SELECT p.*, pr.name as produit_nom, pr.price, pr.image, pr.stock, pr.unit, prd.name as producteur_nom
+                FROM panier_details p
+                JOIN products pr ON p.produit_id = pr.id
+                JOIN producteurs prd ON pr.producteur_id = prd.id
                 WHERE p.panier_id = (SELECT id FROM paniers WHERE user_id = ?)";
         $stmt = $pdo->prepare($sql);
         $stmt->execute([$user_id]);
@@ -78,7 +78,7 @@ function getPanier($pdo, $user_id) {
 function calculerTotalPanier($panier_items) {
     $total = 0;
     foreach ($panier_items as $item) {
-        $total += $item['prix'] * $item['quantite'];
+        $total += $item['price'] * $item['quantite'];
     }
     return $total;
 }

--- a/public/ajouter-au-panier.php
+++ b/public/ajouter-au-panier.php
@@ -28,7 +28,7 @@ if (!$produit_id || !$quantite || $quantite <= 0) {
 }
 
 // Vérifier si le produit existe et est en stock
-$sql = "SELECT stock FROM produits WHERE id = ?";
+$sql = "SELECT stock FROM products WHERE id = ?";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$produit_id]);
 $produit = $stmt->fetch();

--- a/public/catalogue.php
+++ b/public/catalogue.php
@@ -20,7 +20,7 @@ $conditions = [];
 $params     = [];
 
 if ($search) {
-    $conditions[]          = '(p.name LIKE :searchName OR p.category LIKE :searchCat)';
+    $conditions[]          = '(p.name LIKE :searchName OR c.label LIKE :searchCat)';
     $params[':searchName'] = "%{$search}%";
     $params[':searchCat']  = "%{$search}%";
 }
@@ -124,12 +124,12 @@ $categories = $pdo->query('SELECT id, label FROM categories ORDER BY label')
             <?php foreach ($catalogue as $product): ?>
                 <div class="col-sm-6 col-md-4 col-lg-3 mb-4">
                     <div class="card h-100">
-                        <?php if ($product['image_url']): ?>
-                            <img src="<?php echo htmlspecialchars($product['image_url']); ?>" class="card-img-top" alt="<?php echo htmlspecialchars($product['nom']); ?>">
+                        <?php if ($product['image']): ?>
+                            <img src="<?php echo htmlspecialchars($product['image']); ?>" class="card-img-top" alt="<?php echo htmlspecialchars($product['name']); ?>">
                         <?php endif; ?>
                         <div class="card-body d-flex flex-column">
-                            <h5 class="card-title"><?php echo htmlspecialchars($product['nom']); ?></h5>
-                            <p class="card-text mb-2"><?php echo number_format($product['prix'], 2); ?> €</p>
+                            <h5 class="card-title"><?php echo htmlspecialchars($product['name']); ?></h5>
+                            <p class="card-text mb-2"><?php echo number_format($product['price'], 2); ?> €</p>
                             <form method="post" action="ajouter-au-panier.php" class="mt-auto add-to-cart-form">
                                 <input type="hidden" name="produit_id" value="<?php echo $product['id']; ?>">
                                 <input type="hidden" name="quantite" value="1">

--- a/public/panier.php
+++ b/public/panier.php
@@ -10,10 +10,10 @@ if (!isset($_SESSION['user_id'])) {
 }
 
 // Récupérer le panier de l'utilisateur
-$sql = "SELECT p.*, pr.nom as produit_nom, pr.prix, pr.image_url, pr.stock, pr.unite, prd.nom as producteur_nom 
-        FROM panier_details p 
-        JOIN produits pr ON p.produit_id = pr.id 
-        JOIN producteurs prd ON pr.producteur_id = prd.id 
+$sql = "SELECT p.*, pr.name as produit_nom, pr.price, pr.image, pr.stock, pr.unit, prd.name as producteur_nom
+        FROM panier_details p
+        JOIN products pr ON p.produit_id = pr.id
+        JOIN producteurs prd ON pr.producteur_id = prd.id
         WHERE p.panier_id = (SELECT id FROM paniers WHERE user_id = ?)";
 $stmt = $pdo->prepare($sql);
 $stmt->execute([$_SESSION['user_id']]);
@@ -21,7 +21,7 @@ $panier_items = $stmt->fetchAll();
 
 $total = 0;
 foreach ($panier_items as $item) {
-    $total += $item['prix'] * $item['quantite'];
+    $total += $item['price'] * $item['quantite'];
 }
 
 // Traitement des actions sur le panier
@@ -88,15 +88,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             <div class="card-body">
                                 <div class="row">
                                     <div class="col-md-2">
-                                        <?php if ($item['image_url']): ?>
-                                            <img src="<?php echo htmlspecialchars($item['image_url']); ?>" class="img-fluid rounded" alt="<?php echo htmlspecialchars($item['produit_nom']); ?>">
+                                        <?php if ($item['image']): ?>
+                                            <img src="<?php echo htmlspecialchars($item['image']); ?>" class="img-fluid rounded" alt="<?php echo htmlspecialchars($item['produit_nom']); ?>">
                                         <?php endif; ?>
                                     </div>
                                     <div class="col-md-6">
                                         <h5 class="card-title"><?php echo htmlspecialchars($item['produit_nom']); ?></h5>
                                         <p class="card-text">
                                             Producteur : <?php echo htmlspecialchars($item['producteur_nom']); ?><br>
-                                            Prix unitaire : <?php echo number_format($item['prix'], 2); ?> € / <?php echo htmlspecialchars($item['unite']); ?>
+                                            Prix unitaire : <?php echo number_format($item['price'], 2); ?> € / <?php echo htmlspecialchars($item['unit']); ?>
                                         </p>
                                     </div>
                                     <div class="col-md-2">
@@ -111,7 +111,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                     </div>
                                     <div class="col-md-2 text-end">
                                         <p class="card-text">
-                                            <strong><?php echo number_format($item['prix'] * $item['quantite'], 2); ?> €</strong>
+                                            <strong><?php echo number_format($item['price'] * $item['quantite'], 2); ?> €</strong>
                                         </p>
                                         <form method="POST" action="">
                                             <input type="hidden" name="action" value="remove">


### PR DESCRIPTION
## Summary
- update queries to reference `products` table columns (`name`, `price`, `image`, `category_id`)
- fix product field usage in catalogue and basket pages
- update add-to-cart query

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847230ddd8483328c64006060df3890