### PR TITLE
Update debug settings for APP_ENV

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -85,11 +85,11 @@ try {
 date_default_timezone_set('Europe/Paris');
 
 // Configuration des erreurs
-if (APP_DEBUG) {
+if (APP_ENV === 'development') {
     error_reporting(E_ALL);
     ini_set('display_errors', 1);
     ini_set('display_startup_errors', 1);
 } else {
     error_reporting(0);
     ini_set('display_errors', 0);
-} 
+}

--- a/public/process_contact.php
+++ b/public/process_contact.php
@@ -1,9 +1,4 @@
 <?php
-// Activation de l'affichage des erreurs pour le débogage
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-
 require_once __DIR__ . "/../vendor/autoload.php";
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
@@ -12,6 +7,15 @@ try {
     // Chargement des variables d'environnement
     $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../');
     $dotenv->load();
+
+    // Affichage des erreurs uniquement en environnement de développement
+    if (getenv('APP_ENV') === 'development') {
+        ini_set('display_errors', 1);
+        ini_set('display_startup_errors', 1);
+        error_reporting(E_ALL);
+    } else {
+        ini_set('display_errors', 0);
+    }
 
     // Vérification des données du formulaire
     if ($_SERVER["REQUEST_METHOD"] == "POST") {
@@ -70,10 +74,12 @@ try {
         $mail = new PHPMailer(true);
 
         // Configuration du serveur
-        $mail->SMTPDebug = 2; // Active le débogage SMTP
-        $mail->Debugoutput = function($str, $level) {
-            error_log("PHPMailer Debug: $str");
-        };
+        if (getenv('APP_ENV') === 'development') {
+            $mail->SMTPDebug = 2; // Active le débogage SMTP
+            $mail->Debugoutput = function($str, $level) {
+                error_log("PHPMailer Debug: $str");
+            };
+        }
 
         $mail->isSMTP();
         $mail->Host = $_ENV['MAIL_HOST'];


### PR DESCRIPTION
## Summary
- enable PHP error display only when `APP_ENV` is `development`
- activate PHPMailer's SMTP debugging only in development mode

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684714004a00833283afa42fe9ee5639