### PR TITLE
Replace FILTER_SANITIZE_STRING usage

### DIFF
--- a/public/process_contact.php
+++ b/public/process_contact.php
@@ -50,10 +50,10 @@ try {
         }
 
         // Validation des champs du formulaire
-        $name = filter_input(INPUT_POST, 'name', FILTER_SANITIZE_STRING);
+        $name = filter_input(INPUT_POST, 'name', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         $email = filter_input(INPUT_POST, 'email', FILTER_SANITIZE_EMAIL);
-        $subject = filter_input(INPUT_POST, 'subject', FILTER_SANITIZE_STRING);
-        $message = filter_input(INPUT_POST, 'message', FILTER_SANITIZE_STRING);
+        $subject = filter_input(INPUT_POST, 'subject', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        $message = filter_input(INPUT_POST, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 
         if (!$name || !$email || !$subject || !$message) {
             header('Location: contact.php?error=missing_fields');


### PR DESCRIPTION
## Summary
- switch to `FILTER_SANITIZE_FULL_SPECIAL_CHARS` when sanitizing contact form data

## Testing
- `composer install`
- `./vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_684713f42d78833287a110ad0004b897